### PR TITLE
Developer Debugging and TumblR RSS bypass (fixes RSS feeds from TumblR)

### DIFF
--- a/includes/bp-geb-debug.php
+++ b/includes/bp-geb-debug.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Class bp-geb-debug is a debugging module. 
+ * To activate, define('_BP_GEB_DEBUG_ON_', TRUE); before the class is loaded.
+ *
+ * @author lordmatt
+ */
+class bp_geb_debug {
+		protected $debug=array();
+		protected $debugfile = '';		
+		
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
+			$this->debugfile = _BP_GEB_FILE_;// set this be defining it before the plugin is loaded
+			$this->debug('['.gmdate( "Y-m-d H:i:s" ).'] Constructed bp_geb_debug');
+		}
+		
+		public function __destruct() {
+			if(!_BP_GEB_DEBUG_ON_){
+				return;
+			}
+			$this->log_all();
+		}
+		/**
+		 * Forces the class to log to alt file.
+		 * @param string $file
+		 */
+		public function force_alt_log($file){
+			$this->debugfile=$file;
+		}
+		/**
+		 * 
+		 * @param string $message
+		 * @param mixed $var
+		 */
+		public function debug($message,$var=''){			
+			if(_BP_GEB_DEBUG_ON_){
+				$this->debug[]=array($message,$var);
+				if(count($this->debug)>9){
+					$this->log();
+				}
+			}
+		}
+		
+		/**
+		 * Flush to log file
+		 */
+		public function log_all(){
+			if(_BP_GEB_DEBUG_ON_){
+				$this->log();
+			}
+			return;
+		}
+		
+		protected function log(){
+			if(is_writable ($this->debugfile)){
+				$my_file = 'file.txt';
+				@$handle = fopen($this->debugfile, 'a');
+				if($handle===FALSE){
+					return;
+				}
+				foreach($this->debug as $k=>$log){
+					$data = "[{$k}] ".$log[0] . ' : ' . print_r($log[1],TRUE) . "\n";
+					fwrite($handle, $data);
+				}
+				$this->debug=array();
+				fclose($handle);
+			}
+		}
+}
+
+$bp_geb_debug = new bp_geb_debug();
+$bp_geb_debug->debug('Logging started: '.time(),'',TRUE);
+# ALT: error_log("Starting\n", 3, _BP_GEB_FILE_);

--- a/includes/index.php
+++ b/includes/index.php
@@ -1,0 +1,8 @@
+<?php
+
+/* 
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+

--- a/includes/temp.php
+++ b/includes/temp.php
@@ -1,0 +1,46 @@
+<?php
+
+/* 
+ * Unfuck Tumblr
+ */
+/*
+ * Tumblr being dum fix 
+ * @Based-on: <https://github.com/Arvedui/tt-rss-tumblr-gdpr> 
+ */
+if (!preg_match(";^https?://.*\.tumblr.com/rss$;", $fetch_url)) {
+	return $feed_data;
+}
+$curl_handle = curl_init();
+curl_setopt($curl_handle, CURLOPT_COOKIEJAR, "/dev/null");
+curl_setopt($curl_handle, CURLOPT_COOKIEFILE, "/dev/null");
+curl_setopt($curl_handle, CURLOPT_RETURNTRANSFER, true);
+// Configure curl handle for acquiring the cookie
+$data = array(
+	"eu_resident" => "True",
+	"gdpr_consent_core" => "False",
+	"gdpr_consent_first_party_ads" => "False",
+	"gdpr_consent_search_history" => "False",
+	"gdpr_consent_third_party_ads" => "False",
+	"gdpr_is_acceptable_age" => "False",
+	"redirect_to" => $fetch_url);
+curl_setopt($curl_handle, CURLOPT_IPRESOLVE,  CURL_IPRESOLVE_V4);
+curl_setopt($curl_handle, CURLOPT_URL, "https://www.tumblr.com/svc/privacy/consent");
+curl_setopt($curl_handle, CURLOPT_POST, true);
+curl_setopt($curl_handle, CURLOPT_POSTFIELDS, http_build_query($data));
+curl_exec($curl_handle);
+// Configure handle for actual rss request
+curl_setopt($curl_handle, CURLOPT_POST, false);
+curl_setopt($curl_handle, CURLOPT_POSTFIELDS, "");
+curl_setopt($curl_handle, CURLOPT_URL, $fetch_url);
+$data = curl_exec($curl_handle);
+curl_close($curl_handle);
+return $data;
+
+
+
+$retryBecauseFailed = true; // when fetch was not RSS.
+if (preg_match(";^https?://.*\.tumblr.com/rss$;", $fetch_url)||$retryBecauseFailed) {
+	$response = wp_remote_get("https://www.tumblr.com/svc/privacy/consent");
+	$args=array('cookies'=>$response['cookies']);
+	return wp_remote_get($fetch_url,$args);
+}

--- a/index.php
+++ b/index.php
@@ -1,0 +1,8 @@
+<?php
+
+/* 
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+

--- a/loader.php
+++ b/loader.php
@@ -16,6 +16,13 @@ Author URI: http://profiles.wordpress.org/apeatling/
  * Only load the plugin functions if BuddyPress is loaded and initialized.
  */
 function bp_groupblogs_init() {
+	if(!defined( '_BP_GEB_DEBUG_ON_' )){
+		define('_BP_GEB_DEBUG_ON_',FALSE);
+	}
+	if(!defined( '_BP_GEB_FILE_' )){
+		define('_BP_GEB_FILE_', dirname( __FILE__ ) . '/debug.log');
+	}
+	require( dirname( __FILE__ ) . '/includes/bp-geb-debug.php' );
 	require( dirname( __FILE__ ) . '/includes/bp-groups-externalblogs.php' );
 }
 add_action( 'bp_init', 'bp_groupblogs_init' );


### PR DESCRIPTION
Tested in my local dev, this update provides a debug class which enables devs to profile how the plugin is working and it copes with Tumblr being total dicks about EU compliance laws and messing up their RSS feeds. It does this by outright lying to Tumblr and pretending to be (1) Google and (2) a browser with the right cookie pre-agreeing to privacy settings. It only does this for Tumblr.com addresses.