### PR TITLE
Fixes external blog updates does not update group last active time

### DIFF
--- a/includes/bp-groups-externalblogs.php
+++ b/includes/bp-groups-externalblogs.php
@@ -339,6 +339,7 @@ if ( class_exists('BP_Group_Extension' ) ) {
 				// save rss guid as activity meta
 				bp_activity_update_meta( $aid, 'exb_guid', $post['guid'] );
 				bp_activity_update_meta( $aid, 'exb_feedurl', $post['feedurl'] );
+				groups_update_groupmeta( $group_id, 'last_activity', bp_core_current_time() );
 			}
 		}
 


### PR DESCRIPTION
As per my bug report, this fixes the group last active time not updating.